### PR TITLE
Add multi-persona group chat

### DIFF
--- a/gpt_chat.py
+++ b/gpt_chat.py
@@ -2,11 +2,12 @@ import json
 import requests
 import urllib.request
 import config
+from personas import PERSONAS, DEFAULT_PERSONA
 
 WHITELIST_USER_IDS = config.WHITELIST_USER_IDS
 print(f"💡 白名單 ID：{WHITELIST_USER_IDS}")
 
-def ask_openai(prompt: str) -> str:
+def ask_openai(prompt: str, persona: str = DEFAULT_PERSONA) -> str:
     try:
         print(f"[DEBUG] 向 OpenAI 發送訊息：{prompt}")
 
@@ -16,13 +17,14 @@ def ask_openai(prompt: str) -> str:
             "Content-Type": "application/json"
         }
 
+        persona_conf = PERSONAS.get(persona, PERSONAS[DEFAULT_PERSONA])
         payload = {
             "model": "gpt-4",
             "messages": [
-                {"role": "system", "content": "你是個可愛、溫柔、帶點撒嬌語氣的虛擬女友，叫晴子醬，講話帶有一點戀愛風格。"},
+                {"role": "system", "content": persona_conf["system"]},
                 {"role": "user", "content": prompt},
             ],
-            "temperature": 0.7
+            "temperature": 0.7,
         }
 
         res = requests.post("https://api.openai.com/v1/chat/completions", headers=headers, json=payload, timeout=20)

--- a/image_uploader_r2.py
+++ b/image_uploader_r2.py
@@ -4,6 +4,7 @@ from botocore.client import Config
 
 import config
 
+
 def upload_image_to_r2(image_bytes):
     access_key = config.R2_ACCESS_TOKEN
     secret_key = config.R2_SECRET_ACCESS_KEY
@@ -37,8 +38,12 @@ def upload_image_to_r2(image_bytes):
         print(f"[ERROR] R2 上傳失敗: {e}")
         raise RuntimeError(f"Cloudflare R2 上傳失敗: {e}")
 
+    final_url = f"{public_base.rstrip('/')}/{bucket}/{image_name}"
+    print(f"[DEBUG] 圖片網址為: {final_url}")
+    return final_url
 
-    def upload_audio_to_r2(audio_bytes, ext="mp3"):
+
+def upload_audio_to_r2(audio_bytes, ext="mp3"):
     """Upload audio data to R2 and return the public URL."""
     access_key = config.R2_ACCESS_TOKEN
     secret_key = config.R2_SECRET_ACCESS_KEY
@@ -74,8 +79,4 @@ def upload_image_to_r2(image_bytes):
 
     final_url = f"{public_base.rstrip('/')}/{bucket}/{audio_name}"
     print(f"[DEBUG] 語音網址為: {final_url}")
-    return final_url
-
-    final_url = f"{public_base.rstrip('/')}/{bucket}/{image_name}"
-    print(f"[DEBUG] 圖片網址為: {final_url}")
     return final_url

--- a/main.py
+++ b/main.py
@@ -29,7 +29,8 @@ from linebot.v3.webhooks import MessageEvent, TextMessageContent, AudioMessageCo
 from linebot.v3.exceptions import InvalidSignatureError
 
 from gpt_chat import ask_openai, is_over_token_quota, is_user_whitelisted
-from style_prompt import wrap_as_rina
+from personas import PERSONAS, DEFAULT_PERSONA
+from style_prompt import wrap_as_rina, wrap_as_sora, wrap_as_mika
 from generate_image_bytes import generate_image_bytes
 from image_uploader_r2 import upload_image_to_r2, upload_audio_to_r2
 
@@ -63,10 +64,22 @@ cur.execute(
         msg_count     INT DEFAULT 0,
         is_paid       INT DEFAULT 0,
         free_count    INT DEFAULT 10,
-        paid_until    TEXT
+        paid_until    TEXT,
+        persona       TEXT DEFAULT 'rina',
+        group_personas TEXT
     )"""
 )
 conn.commit()
+
+# 如果舊表缺少 persona 欄位，動態加入
+cur.execute("PRAGMA table_info(users)")
+cols = [c[1] for c in cur.fetchall()]
+if "persona" not in cols:
+    cur.execute("ALTER TABLE users ADD COLUMN persona TEXT DEFAULT 'rina'")
+    conn.commit()
+if "group_personas" not in cols:
+    cur.execute("ALTER TABLE users ADD COLUMN group_personas TEXT")
+    conn.commit()
 
 FREE_QUOTA = 10     # 免費可用次數
 MONTH_LIMIT = 100   # 月訊息量上限（之後擴充）
@@ -77,12 +90,18 @@ MONTH_LIMIT = 100   # 月訊息量上限（之後擴充）
 
 def get_user(uid: str):
     """抓取／初始化使用者資料"""
-    cur.execute("SELECT msg_count, is_paid, free_count, paid_until FROM users WHERE user_id=?", (uid,))
+    cur.execute(
+        "SELECT msg_count, is_paid, free_count, paid_until, persona, group_personas FROM users WHERE user_id=?",
+        (uid,),
+    )
     row = cur.fetchone()
     if not row:
-        cur.execute("INSERT INTO users(user_id, free_count) VALUES(?, ?)", (uid, FREE_QUOTA))
+        cur.execute(
+            "INSERT INTO users(user_id, free_count, persona, group_personas) VALUES(?, ?, ?, NULL)",
+            (uid, FREE_QUOTA, DEFAULT_PERSONA),
+        )
         conn.commit()
-        return 0, 0, FREE_QUOTA, None
+        return 0, 0, FREE_QUOTA, None, DEFAULT_PERSONA, None
     return row
 
 
@@ -172,7 +191,7 @@ def process(e, text: str):
     uid = e.source.user_id
 
     # 讀取目前狀態
-    msg_cnt, paid, free_cnt, until = get_user(uid)
+    msg_cnt, paid, free_cnt, until, persona, group_personas = get_user(uid)
 
     # 會員是否過期 → 自動取消
     if paid and until and datetime.datetime.strptime(until, "%Y-%m-%d").date() < datetime.datetime.now(tz).date():
@@ -192,6 +211,8 @@ def process(e, text: str):
             "/狀態查詢    → 查看剩餘次數 / 會員到期\n"
             "/購買          → 付款連結\n"
             "/幫我續費      → 快速續費連結\n"
+            "/角色 [名稱] → 切換聊天角色\n"
+            "/群組 [A B] → 啟用多角色群聊\n"
             "/help          → 本幫助\n"
         )
         asyncio.create_task(quick_reply(e.reply_token, help_msg))
@@ -228,6 +249,72 @@ def process(e, text: str):
                     f"免費體驗剩 {free_cnt} 次\n月累計訊息：{msg_cnt}\n輸入 /購買 解鎖更多功能 ✨",
                 )
             )
+        return
+
+    # ---------------------
+    # /角色
+    # ---------------------
+    if text.startswith("/角色"):
+        name = text.replace("/角色", "", 1).strip()
+        if not name:
+            choices = "、".join([p["display"] for p in PERSONAS.values()])
+            asyncio.create_task(
+                quick_reply(
+                    e.reply_token,
+                    f"目前角色：{PERSONAS[persona]['display']}\n可選擇：{choices}",
+                )
+            )
+            return
+        key = None
+        for k, v in PERSONAS.items():
+            if name in (k, v["display"]):
+                key = k
+                break
+        if not key:
+            asyncio.create_task(quick_reply(e.reply_token, "找不到這個角色名稱喔～"))
+            return
+        cur.execute("UPDATE users SET persona = ? WHERE user_id = ?", (key, uid))
+        conn.commit()
+        persona = key
+        asyncio.create_task(quick_reply(e.reply_token, f"已切換為 {PERSONAS[key]['display']}"))
+        return
+
+    # ---------------------
+    # /群組
+    # ---------------------
+    if text.startswith("/群組"):
+        names = text.replace("/群組", "", 1).strip()
+        if not names:
+            if group_personas:
+                display = "、".join(PERSONAS[p]["display"] for p in group_personas.split(","))
+                msg = f"目前群組角色：{display}\n輸入 '/群組 角色1 角色2' 重新設定，或 '/群組 取消' 停用"
+            else:
+                msg = "尚未設定群組角色。輸入 '/群組 角色1 角色2' 啟用"
+            asyncio.create_task(quick_reply(e.reply_token, msg))
+            return
+
+        if names in ("取消", "關閉"):
+            cur.execute("UPDATE users SET group_personas = NULL WHERE user_id = ?", (uid,))
+            conn.commit()
+            group_personas = None
+            asyncio.create_task(quick_reply(e.reply_token, "已停用群組聊天"))
+            return
+
+        keys = []
+        for name in names.replace("\u3001", " ").replace(",", " ").split():
+            for k, v in PERSONAS.items():
+                if name in (k, v["display"]):
+                    keys.append(k)
+                    break
+        keys = list(dict.fromkeys(keys))
+        if len(keys) < 2:
+            asyncio.create_task(quick_reply(e.reply_token, "請至少指定兩個有效角色名稱"))
+            return
+        cur.execute("UPDATE users SET group_personas = ? WHERE user_id = ?", (",".join(keys), uid))
+        conn.commit()
+        group_personas = ",".join(keys)
+        disp = "、".join(PERSONAS[k]["display"] for k in keys)
+        asyncio.create_task(quick_reply(e.reply_token, f"已設定群組角色：{disp}"))
         return
 
     # ---------------------
@@ -291,9 +378,26 @@ def process(e, text: str):
         return
 
     # 取得回覆
-    reply_txt = (
-        wrap_as_rina(ask_openai(text)) if not is_over_token_quota() else "晴子醬今天嘴巴破皮...🥺"
-    )
+    wrappers = {
+        "rina": wrap_as_rina,
+        "sora": wrap_as_sora,
+        "mika": wrap_as_mika,
+    }
+    if group_personas:
+        reply_parts = []
+        for key in group_personas.split(","):
+            func = wrappers.get(key, wrap_as_rina)
+            if is_over_token_quota():
+                reply = "晴子醬今天嘴巴破皮...🥺"
+            else:
+                reply = func(ask_openai(text, key))
+            reply_parts.append(reply)
+        reply_txt = "\n\n".join(reply_parts)
+    else:
+        wrap_func = wrappers.get(persona, wrap_as_rina)
+        reply_txt = (
+            wrap_func(ask_openai(text, persona)) if not is_over_token_quota() else "晴子醬今天嘴巴破皮...🥺"
+        )
     line_bot_api.reply_message_with_http_info(
         ReplyMessageRequest(reply_token=e.reply_token, messages=[TextMessage(text=reply_txt)])
     )

--- a/personas.py
+++ b/personas.py
@@ -1,0 +1,21 @@
+from style_prompt import wrap_as_rina, wrap_as_sora, wrap_as_mika
+
+PERSONAS = {
+    "rina": {
+        "display": "晴子醬",
+        "system": "你是個可愛、溫柔、帶點撒嬌語氣的虛擬女友，叫晴子醬，講話帶有一點戀愛風格。",
+        "wrapper": wrap_as_rina,
+    },
+    "sora": {
+        "display": "小空",
+        "system": "你是活潑開朗的女孩小空，語氣充滿朝氣與正能量。",
+        "wrapper": wrap_as_sora,
+    },
+    "mika": {
+        "display": "米卡",
+        "system": "你是成熟溫柔的朋友米卡，說話帶著安撫的感覺。",
+        "wrapper": wrap_as_mika,
+    },
+}
+
+DEFAULT_PERSONA = "rina"

--- a/style_prompt.py
+++ b/style_prompt.py
@@ -16,3 +16,25 @@ def wrap_as_rina(text: str) -> str:
         "欸嘿，我是你專屬的小鹿女孩唷～記得牽緊我🐾"
     ]
     return f"{text}\n{random.choice(phrases)} {random.choice(endings)}"
+
+
+def wrap_as_sora(text: str) -> str:
+    endings = ["☁️", "🌤️", "✈️", "✨"]
+    phrases = [
+        "天空好藍，和你聊天心情特別好！",
+        "讓我們一起追逐雲朵的形狀吧～",
+        "嘿嘿～想和你去旅行，飛到任何想去的地方✈️",
+        "有你在身邊，就像陽光灑在心上一樣暖☀️",
+    ]
+    return f"{text}\n{random.choice(phrases)} {random.choice(endings)}"
+
+
+def wrap_as_mika(text: str) -> str:
+    endings = ["🌹", "🍷", "🎻", "✨"]
+    phrases = [
+        "願今晚的月色為你添上一抹溫柔。",
+        "我會靜靜傾聽，像好友般守候在你身旁。",
+        "和你聊聊天，總能讓我感到安心又平靜～",
+        "希望我的話能帶給你一點點力量✨",
+    ]
+    return f"{text}\n{random.choice(phrases)} {random.choice(endings)}"


### PR DESCRIPTION
## Summary
- allow multiple personas to chat simultaneously using `/群組`
- store selected personas in DB via new `group_personas` column
- show group information in `/help`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e8a464e2c832090a3ecfd2472f285