### PR TITLE
Add ECPay checkout endpoints

### DIFF
--- a/ecpay_utils.py
+++ b/ecpay_utils.py
@@ -1,0 +1,12 @@
+import urllib.parse
+import hashlib
+
+
+def gen_check_mac_value(params, hash_key, hash_iv):
+    sorted_params = sorted(params.items())
+    encode_str = (
+        f"HashKey={hash_key}&" + "&".join(f"{k}={v}" for k, v in sorted_params) + f"&HashIV={hash_iv}"
+    )
+    encode_str = urllib.parse.quote_plus(encode_str).lower()
+    check_mac_value = hashlib.sha256(encode_str.encode('utf-8')).hexdigest().upper()
+    return check_mac_value


### PR DESCRIPTION
## Summary
- add minimal ECPay checkout and callback routes in main
- expose merchant credentials via environment variables
- implement helper function in new `ecpay_utils` module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868cd1ff1fc83208fa48faacda39329