### PR TITLE
Fix deployment issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -672,4 +672,5 @@ sched.start()
 # 執行 FastAPI
 # ---------------------------
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level="warning")
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("main:app", host="0.0.0.0", port=port, log_level="warning")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-line-bot-sdk
+line-bot-sdk>=3
 openai
 python-dotenv
 requests


### PR DESCRIPTION
## Summary
- ensure port can be overridden by `PORT` env variable
- require `line-bot-sdk>=3` to support `linebot.v3` imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868d851d5208320baf55fab61df5454